### PR TITLE
fix: include sns_canister_ids

### DIFF
--- a/.github/workflows/create_neuron.yml
+++ b/.github/workflows/create_neuron.yml
@@ -28,12 +28,18 @@ jobs:
           curl -LJO https://github.com/dfinity/quill/releases/download/v0.4.2/quill-linux-x86_64-musl
           mv quill-linux-x86_64-musl quill
           chmod +x quill
+
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Stake Neuron
         run: |
           touch actions_identity.pem
           echo "${{ secrets.ESTATE_DAO_SNS_PROPOSAL_SUBMISSION_IDENTITY_PRIVATE_KEY }}" > actions_identity.pem
           ./quill --pem-file actions_identity.pem sns stake-neuron \
-            --amount 500 --memo 69420 | tee stake_request.json
+            --amount 500 --memo 69420 --canister-ids-file ./sns_canister_ids.json | tee stake_request.json
           
           # Send the stake request
           # ./quill send stake_request.json --yes  | tee stake_response.log

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist/
 
 # environment variables
 .env
+
+quill

--- a/sns_canister_ids.json
+++ b/sns_canister_ids.json
@@ -1,0 +1,7 @@
+{
+    "root_canister_id": "abhsa-pyaaa-aaaaq-aac3q-cai",
+    "swap_canister_id": "bcl3g-3aaaa-aaaaq-aac5a-cai",
+    "ledger_canister_id": "bliq2-niaaa-aaaaq-aac4q-cai",
+    "index_canister_id": "bfk5s-wyaaa-aaaaq-aac5q-cai",
+    "governance_canister_id": "bmjwo-aqaaa-aaaaq-aac4a-cai"
+}


### PR DESCRIPTION
- update workflows
- sns_canster_ids are from estate_DAO root canister -> list_sns_canisters - name: Checkout repo and submodules uses: actions/checkout@v3 with: submodules: recursive